### PR TITLE
Send email from shop to customer instead of vice versa

### DIFF
--- a/Block/ContactForm.php
+++ b/Block/ContactForm.php
@@ -29,7 +29,7 @@ class ContactForm extends \Magento\Contact\Block\ContactForm {
 			$objectManager = \Magento\Framework\App\ObjectManager::getInstance();
 			$helper = $objectManager->get('SY\Contact\Helper\Data');
 			$json = $objectManager->get('Magento\Framework\Serialize\Serializer\Json');
-			$fields = $helper->getConfig(
+			$fields = $helper->getContactConfig(
 				'general/fields',
 				$this->_storeManager->getStore()->getId()
 			);

--- a/Controller/Form/Post.php
+++ b/Controller/Form/Post.php
@@ -7,16 +7,31 @@
 namespace SY\Contact\Controller\Form;
 
 use Magento\Framework\App\Action\Action;
-use Magento\Framework\Controller\ResultFactory; 
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\Controller\ResultFactory;
+use Psr\Log\LoggerInterface;
 
 class Post extends Action {
-	public function execute() {
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(Context $context, LoggerInterface $logger)
+    {
+        parent::__construct($context);
+
+        $this->logger = $logger;
+    }
+
+    public function execute() {
 		$validator = $this->_objectManager->get('Magento\Framework\Data\Form\FormKey\Validator');
 		if ($validator->validate($this->getRequest())) {
 			$helper = $this->_objectManager->get('SY\Contact\Helper\Data');
 			$json = $this->_objectManager->get('Magento\Framework\Serialize\Serializer\Json');
 			$store = $this->_objectManager->get('Magento\Store\Model\StoreManagerInterface')->getStore();
-			$fields = $helper->getConfig('general/fields', $store->getId());
+			$fields = $helper->getContactConfig('general/fields', $store->getId());
 			$fields = $json->unserialize($fields);
 			$info = [];
 			if(count($fields)>0){
@@ -34,7 +49,8 @@ class Post extends Action {
 				}
 			}
 			if(count($info)>0){
-				$model = $this->_objectManager->get('SY\Contact\Model\Request');
+                $messageManager = $this->_objectManager->get('Magento\Framework\Message\ManagerInterface');
+                $model = $this->_objectManager->get('SY\Contact\Model\Request');
 				$model->setData('info', $json->serialize($info));
 				//used to support hidden fields
                 $model->setData('originalParams', $this->getRequest()->getParams());
@@ -42,11 +58,13 @@ class Post extends Action {
 					$model->save();
 					if($model->getId()){
 						$email = $this->_objectManager->get('SY\Contact\Helper\Email');
-						$email->recive($model, $store->getId());
-						$messageManager = $this->_objectManager->get('Magento\Framework\Message\ManagerInterface');
-						$messageManager->addSuccess(__('Thanks for contacting us with your comments and questions. We\'ll respond to you very soon.'));
+                        $email->receive($model, $store->getId());
+                        $messageManager->addSuccess(__('Thanks for contacting us with your comments and questions. We\'ll respond to you very soon.'));
 					}
-				} catch (\Exception $e) {}
+                } catch (\Exception $e) {
+                    $this->logger->critical($e->getMessage(), ['exception' => $e]);
+                    $messageManager->addError(__("We're sorry, an error has occurred while generating this email."));
+                }
 			}
 		}
 		$resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1,19 +1,35 @@
 <?php
 /**
  * Contact
- * 
+ *
  * @author Slava Yurthev
  */
 namespace SY\Contact\Helper;
 
 use \Magento\Framework\App\Helper\AbstractHelper;
-use \Magento\Store\Model\StoreManagerInterface;
-use \Magento\Framework\ObjectManagerInterface;
-use \Magento\Framework\App\Helper\Context;
 use \Magento\Store\Model\ScopeInterface;
 
-class Data extends AbstractHelper {
-	public function getConfig($field, $storeId = 0){
-		return $this->scopeConfig->getValue('sy_contact/'.$field, ScopeInterface::SCOPE_STORE, $storeId);
-	}
+class Data extends AbstractHelper
+{
+    /**
+     * @param string $path
+     * @param int $storeId
+     *
+     * @return mixed
+     */
+    public function getContactConfig(string $path, int $storeId = 0)
+    {
+        return $this->getConfig('sy_contact/' . $path, $storeId);
+    }
+
+    /**
+     * @param string $path
+     * @param int $storeId
+     *
+     * @return mixed
+     */
+    public function getConfig(string $path, int $storeId = 0)
+    {
+        return $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $storeId);
+    }
 }

--- a/Plugin/ContactForm.php
+++ b/Plugin/ContactForm.php
@@ -17,7 +17,7 @@ class ContactForm {
 		$this->_helper = $helper;
 	}
 	public function beforeToHtml($subject){
-		if($this->_helper->getConfig(
+		if($this->_helper->getContactConfig(
 				'general/active', 
 				$this->_storeManagerInterface->getStore()->getId()
 			) == "1"){

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "OSL-3.0"
     ],
     "require": {
-        "php": "~7.0.0|~7.1.0|~7.2.0"
+        "php": "~7.0|~7.1|~7.2"
     },
     "type": "magento2-module",
     "version": "1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
         "OSL-3.0"
     ],
     "require": {
-        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0"
+        "php": "~7.0.0|~7.1.0|~7.2.0"
     },
     "type": "magento2-module",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "Slava Yurthev",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -64,14 +64,17 @@
 					<label>Email Template</label>
 					<source_model>Magento\Config\Model\Config\Source\Email\Template</source_model>
 				</field>
-				<field id="send_to" translate="label comment" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
-					<label>Send To</label>
-					<comment>Manager Email to Recive New Requests</comment>
+				<field id="send_from_name" translate="label comment" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+					<label>Send From Name</label>
+					<comment>Name from where new requests are send to customer - If empty defaults to the Name configured in General > Store Email Addresses > Sales Representative </comment>
 				</field>
-				<field id="add_customer_in_cc" translate="label comment" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
-					<label>Send to customer in CC</label>
-					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-					<comment>The E-Mail Address from the customer will be set in CC.</comment>
+				<field id="send_from" translate="label comment" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+					<label>Send From</label>
+					<comment>Email from where new requests are send to customer - If empty defaults to the E-Mail configured in General > Store Email Addresses > Sales Representative </comment>
+				</field>
+				<field id="send_to" translate="label comment" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+					<label>Send To</label>
+					<comment>Manager email to receive new requests as BCC - If empty defaults to the E-Mail configured in General > Store Email Addresses > Sales Representative </comment>
 				</field>
 			</group>
 		</section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -21,7 +21,6 @@
 				<active>0</active>
 				<email_template>sy_contact_general_email_template</email_template>
 				<fields>[{"key":"email","label":"E-Mail","field_class":"required validate-email","default_value":"","options":"","show_if":"","field_type":"email"},{"key":"message","label":"Message","field_class":"required","default_value":"","options":"","show_if":"","field_type":"textarea"}]</fields>
-				<add_customer_in_cc>0</add_customer_in_cc>
 			</general>
 		</sy_contact>
 	</default>


### PR DESCRIPTION
This includes some refactoring and improved error handling as well as an
error message to the customer in case the request fails.
The from mail address is fully configurable and defaults to
trans_email/ident_sales.